### PR TITLE
fix: Resolve QAT failures — validation 400s, duplicate 409, phoneNo constraint

### DIFF
--- a/tms-backend/src/main/java/cloudsufi/nextgen/tms/dto/SignUpRequestDTO.java
+++ b/tms-backend/src/main/java/cloudsufi/nextgen/tms/dto/SignUpRequestDTO.java
@@ -28,6 +28,7 @@ public class SignUpRequestDTO {
     @NotBlank
     private String password;
 
+    @NotBlank
     private String phoneNo;
 
     private Role role;

--- a/tms-backend/src/main/java/cloudsufi/nextgen/tms/exception/GlobalExceptionHandler.java
+++ b/tms-backend/src/main/java/cloudsufi/nextgen/tms/exception/GlobalExceptionHandler.java
@@ -5,10 +5,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.time.LocalDateTime;
+import java.util.stream.Collectors;
 
 /**
  * Global exception handler that intercepts application exceptions and
@@ -69,6 +71,24 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponseDTO> handleInvalidTokenException(InvalidTokenException ex, HttpServletRequest request) {
         log.warn("InvalidTokenException handled: {}", ex.getMessage());
         return new ResponseEntity<>(createErrorResponse(ex.getMessage(), HttpStatus.UNAUTHORIZED, request), HttpStatus.UNAUTHORIZED);
+    }
+
+    /**
+     * Handles @Valid bean validation failures and returns 400 Bad Request status.
+     * Collects all field-level constraint violations into a single error message.
+     *
+     * @param ex        The intercepted MethodArgumentNotValidException
+     * @param request   The current HTTP request
+     * @return          ResponseEntity containing the structured ErrorResponse and 400 status
+     * @author Yashas Yadav
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponseDTO> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex, HttpServletRequest request) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        log.warn("MethodArgumentNotValidException handled: {}", message);
+        return new ResponseEntity<>(createErrorResponse(message, HttpStatus.BAD_REQUEST, request), HttpStatus.BAD_REQUEST);
     }
 
     /**

--- a/tms-backend/src/main/java/cloudsufi/nextgen/tms/service/AuthService.java
+++ b/tms-backend/src/main/java/cloudsufi/nextgen/tms/service/AuthService.java
@@ -6,7 +6,7 @@ import cloudsufi.nextgen.tms.dto.SignUpRequestDTO;
 import cloudsufi.nextgen.tms.dto.SignUpResponseDTO;
 import cloudsufi.nextgen.tms.entity.UserEntity;
 import cloudsufi.nextgen.tms.exception.AuthenticationException;
-import cloudsufi.nextgen.tms.exception.BadRequestException;
+import cloudsufi.nextgen.tms.exception.DuplicateResourceException;
 import cloudsufi.nextgen.tms.repository.UserRepository;
 import cloudsufi.nextgen.tms.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
@@ -35,7 +35,7 @@ public class AuthService {
      *
      * @param request DTO containing sign-up details
      * @return the saved user details as {@link SignUpResponseDTO}
-     * @throws BadRequestException if email or username already exists
+     * @throws DuplicateResourceException if email or username already exists
      */
     public SignUpResponseDTO signUp(SignUpRequestDTO request) {
 
@@ -44,12 +44,12 @@ public class AuthService {
 
         userRepository.findByEmail(request.getEmail()).ifPresent(existing -> {
             log.warn("Sign-up failed: Email already exists -> {}", request.getEmail());
-            throw new BadRequestException("User with this email already exists.");
+            throw new DuplicateResourceException("User with this email already exists.");
         });
 
         userRepository.findByUsername(request.getUsername()).ifPresent(existing -> {
             log.warn("Sign-up failed: Username already exists -> {}", request.getUsername());
-            throw new BadRequestException("User with this username already exists.");
+            throw new DuplicateResourceException("User with this username already exists.");
         });
 
         UserEntity user = UserEntity.builder()

--- a/tms-backend/src/test/java/cloudsufi/nextgen/tms/controller/AuthControllerTest.java
+++ b/tms-backend/src/test/java/cloudsufi/nextgen/tms/controller/AuthControllerTest.java
@@ -7,6 +7,7 @@ import cloudsufi.nextgen.tms.dto.SignUpResponseDTO;
 import cloudsufi.nextgen.tms.enums.Role;
 import cloudsufi.nextgen.tms.exception.AuthenticationException;
 import cloudsufi.nextgen.tms.exception.BadRequestException;
+import cloudsufi.nextgen.tms.exception.DuplicateResourceException;
 import cloudsufi.nextgen.tms.repository.UserRepository;
 import cloudsufi.nextgen.tms.service.AuthService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -81,26 +82,27 @@ public class AuthControllerTest {
     }
 
     /**
-     * Verifies that the Controller returns 400 Bad Request when email already exists.
+     * Verifies that the Controller returns 409 Conflict when email already exists.
      */
     @Test
-    @DisplayName("POST /api/auth/signup - Should return 400 Bad Request when email already exists")
-    void signUp_whenEmailAlreadyExists_shouldReturnBadRequest() throws Exception {
+    @DisplayName("POST /api/auth/signup - Should return 409 Conflict when email already exists")
+    void signUp_whenEmailAlreadyExists_shouldReturnConflict() throws Exception {
 
         SignUpRequestDTO request = new SignUpRequestDTO();
         request.setUsername("yashascs");
         request.setEmail("yashas@cs.com");
         request.setPassword("password123");
+        request.setPhoneNo("1234567890");
         request.setRole(Role.ENGINEERING);
 
         when(authService.signUp(any(SignUpRequestDTO.class)))
-                .thenThrow(new BadRequestException("User with this email already exists."));
+                .thenThrow(new DuplicateResourceException("User with this email already exists."));
 
         mockMvc.perform(post("/api/auth/signup")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(result -> assertTrue(result.getResolvedException() instanceof BadRequestException))
+                .andExpect(status().isConflict())
+                .andExpect(result -> assertTrue(result.getResolvedException() instanceof DuplicateResourceException))
                 .andExpect(result -> assertEquals(
                         "User with this email already exists.",
                         result.getResolvedException().getMessage()));

--- a/tms-backend/src/test/java/cloudsufi/nextgen/tms/service/AuthServiceTest.java
+++ b/tms-backend/src/test/java/cloudsufi/nextgen/tms/service/AuthServiceTest.java
@@ -7,7 +7,7 @@ import cloudsufi.nextgen.tms.dto.SignUpResponseDTO;
 import cloudsufi.nextgen.tms.entity.UserEntity;
 import cloudsufi.nextgen.tms.enums.Role;
 import cloudsufi.nextgen.tms.exception.AuthenticationException;
-import cloudsufi.nextgen.tms.exception.BadRequestException;
+import cloudsufi.nextgen.tms.exception.DuplicateResourceException;
 import cloudsufi.nextgen.tms.repository.UserRepository;
 import cloudsufi.nextgen.tms.util.JwtUtil;
 import org.junit.jupiter.api.BeforeEach;
@@ -109,10 +109,11 @@ class AuthServiceTest {
         request.setUsername("yashascs");
         request.setEmail("yashas@cs.com");
         request.setPassword("password123");
+        request.setPhoneNo("1234567890");
 
         when(userRepository.findByEmail("yashas@cs.com")).thenReturn(Optional.of(mockUser));
 
-        BadRequestException exception = assertThrows(BadRequestException.class, () ->
+        DuplicateResourceException exception = assertThrows(DuplicateResourceException.class, () ->
                 authService.signUp(request)
         );
 
@@ -132,11 +133,12 @@ class AuthServiceTest {
         request.setUsername("yashascs");
         request.setEmail("yashas@cs.com");
         request.setPassword("password123");
+        request.setPhoneNo("1234567890");
 
         when(userRepository.findByEmail("yashas@cs.com")).thenReturn(Optional.empty());
         when(userRepository.findByUsername("yashascs")).thenReturn(Optional.of(mockUser));
 
-        BadRequestException exception = assertThrows(BadRequestException.class, () ->
+        DuplicateResourceException exception = assertThrows(DuplicateResourceException.class, () ->
                 authService.signUp(request)
         );
 


### PR DESCRIPTION
## Summary
Fixes all 5 failures identified in QAT by @ansh-parnami-cs.

## Changes

### Bug Fixes
- **Scenarios 3, 4, 9 — Validation failures returning 500 instead of 400**
  Added `MethodArgumentNotValidException` handler to `GlobalExceptionHandler`.
  `@NotBlank` and `@Email` violations now return `400 Bad Request` with field-level error messages instead of falling through to the generic 500 handler.

- **Scenario 5 — Duplicate user returning 400 instead of 409**
  Replaced `BadRequestException` with `DuplicateResourceException` in `AuthService.signUp()` for both email and username duplicate checks. `GlobalExceptionHandler` already maps this to `409 Conflict`.

- **Scenario 2 — Null phoneNo reaching the database and causing 500**
  Added `@NotBlank` to `phoneNo` in `SignUpRequestDTO`. Validation now fails at the DTO level before the request reaches the service or database layer.

## Files Changed
- `dto/SignUpRequestDTO.java` — added `@NotBlank` on `phoneNo`
- `exception/GlobalExceptionHandler.java` — added `MethodArgumentNotValidException` handler
- `service/AuthService.java` — `DuplicateResourceException` instead of `BadRequestException`
- `test/service/AuthServiceTest.java` — updated exception types and request setup
- `test/controller/AuthControllerTest.java` — updated exception types and expected status codes

## QAT Reference
Test proof doc: https://docs.google.com/document/d/1o62bGhYH4YvXNHwQ-kkv5sTqOuNvUtRlQSfelcBf898/edit?usp=sharing
