### PR TITLE
feat(#49): add API to fetch complete ticket details by ID

### DIFF
--- a/tms-backend/src/main/java/cloudsufi/nextgen/tms/controller/TicketController.java
+++ b/tms-backend/src/main/java/cloudsufi/nextgen/tms/controller/TicketController.java
@@ -1,5 +1,6 @@
 package cloudsufi.nextgen.tms.controller;
 
+import cloudsufi.nextgen.tms.dto.TicketDetailsResponse;
 import cloudsufi.nextgen.tms.dto.TicketRaiseRequest;
 import cloudsufi.nextgen.tms.dto.TicketRaiseResponse;
 import cloudsufi.nextgen.tms.service.TicketService;
@@ -40,5 +41,17 @@ public class TicketController {
         TicketRaiseResponse response = ticketService.raiseTicket(request);
 
         return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    /**
+     * Retrieves the complete details of a specific ticket, including its history and attachments.
+     * * @param id The ID of the ticket to retrieve.
+     * @return 200 OK with the TicketDetailsResponse payload.
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<TicketDetailsResponse> getTicketById(@PathVariable("id") Long id) {
+        log.info("REST request to get Ticket ID: {}", id);
+        TicketDetailsResponse response = ticketService.getTicketById(id);
+        return ResponseEntity.ok(response);
     }
 }

--- a/tms-backend/src/main/java/cloudsufi/nextgen/tms/dto/TicketDetailsResponse.java
+++ b/tms-backend/src/main/java/cloudsufi/nextgen/tms/dto/TicketDetailsResponse.java
@@ -1,0 +1,72 @@
+package cloudsufi.nextgen.tms.dto;
+
+import cloudsufi.nextgen.tms.enums.ApprovalStatus;
+import cloudsufi.nextgen.tms.enums.Priority;
+import cloudsufi.nextgen.tms.enums.Status;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+/**
+ * Data Transfer Object (DTO) representing the comprehensive details of a support ticket.
+ * This class serves as the response payload for the "Get Ticket by ID" API, aggregating
+ * core ticket information, assignment details, approval workflows, lightweight attachment
+ * metadata, and a chronological history of audit logs.
+ *
+ * @author Ansh Parnami
+ */
+public class TicketDetailsResponse {
+
+
+    private Long id;
+    private String title;
+    private String description;
+    private Priority priority;
+    private Status status;
+    private LocalDateTime sla;
+
+    private String createdBy;
+    private String assignedTo;
+
+    private boolean isApprovalRequired;
+    private String approver;
+    private ApprovalStatus approvalStatus;
+
+    private LocalDateTime assignedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+
+    private List<AttachmentMetadata> attachments;
+    private List<TicketHistory> history;
+
+    @Data
+    @Builder
+    /**
+     * Nested DTO representing lightweight metadata for a file attached to the ticket.
+     * By returning only metadata (like file size derived from the database BLOB) instead
+     * of the actual binary data, the API ensures high performance and reduced payload size.
+     */
+    public static class AttachmentMetadata {
+        private Long id;
+        private String fileType;
+        private long fileSizeInBytes;
+    }
+    /**
+     * Nested DTO representing a single event in the ticket's audit trail.
+     * This provides a chronological view of actions taken on the ticket, including
+     * what changed, who made the change, and when it occurred.
+     */
+    @Data
+    @Builder
+    public static class TicketHistory {
+        private Long id;
+        private String description;
+        private String createdBy;
+        private LocalDateTime createdAt;
+    }
+}

--- a/tms-backend/src/main/java/cloudsufi/nextgen/tms/repository/AttachmentRepository.java
+++ b/tms-backend/src/main/java/cloudsufi/nextgen/tms/repository/AttachmentRepository.java
@@ -3,10 +3,13 @@ package cloudsufi.nextgen.tms.repository;
 import cloudsufi.nextgen.tms.entity.AttachmentEntity;
 import cloudsufi.nextgen.tms.entity.TicketEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+import java.util.Collection;
 
 /**
  * Repository representing a Ticket's Attachment in the SQL Database
  * @author Ansh Parnami
  **/
 public interface AttachmentRepository extends JpaRepository<AttachmentEntity, Long> {
+    List<AttachmentEntity> findByTicketId(Long ticketId);
 }

--- a/tms-backend/src/main/java/cloudsufi/nextgen/tms/repository/TicketHistoryRepository.java
+++ b/tms-backend/src/main/java/cloudsufi/nextgen/tms/repository/TicketHistoryRepository.java
@@ -3,10 +3,13 @@ package cloudsufi.nextgen.tms.repository;
 import cloudsufi.nextgen.tms.entity.TicketHistoryEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 
 /**
  * Repository representing a Ticket's History in the SQL Database
  * @author Ansh Parnami
  **/
 public interface TicketHistoryRepository extends JpaRepository<TicketHistoryEntity, Long> {
+    List<TicketHistoryEntity> findByTicketId(Long ticketId);
 }

--- a/tms-backend/src/main/java/cloudsufi/nextgen/tms/service/TicketService.java
+++ b/tms-backend/src/main/java/cloudsufi/nextgen/tms/service/TicketService.java
@@ -1,5 +1,6 @@
 package cloudsufi.nextgen.tms.service;
 
+import cloudsufi.nextgen.tms.dto.TicketDetailsResponse;
 import cloudsufi.nextgen.tms.dto.TicketRaiseRequest;
 import cloudsufi.nextgen.tms.dto.TicketRaiseResponse;
 import cloudsufi.nextgen.tms.entity.*;
@@ -192,5 +193,80 @@ public class TicketService {
             }
         });
         log.info("Attachment processing completed.");
+    }
+
+
+
+    /**
+     * Retrieves comprehensive details of a ticket by its unique ID.
+     * This includes core ticket information, chronological history logs,
+     * and metadata for any associated file attachments.
+     *
+     * @param ticketId The unique database identifier of the ticket.
+     * @return A {@link TicketDetailsResponse} containing all aggregated ticket data.
+     * @throws ResourceNotFoundException If no ticket exists with the provided ID.
+     */
+    public TicketDetailsResponse getTicketById(Long ticketId) {
+        log.info("Initiating retrieval of complete ticket details for ID: {}", ticketId);
+
+
+        TicketEntity ticket = ticketRepository.findById(ticketId)
+                .orElseThrow(() -> {
+                    log.error("Ticket retrieval failed. ID not found: {}", ticketId);
+                    return new ResourceNotFoundException("Ticket not found with ID: " + ticketId);
+                });
+
+        List<TicketDetailsResponse.AttachmentMetadata> attachments = fetchAndMapAttachments(ticketId);
+        List<TicketDetailsResponse.TicketHistory> historyLogs = fetchAndMapHistory(ticketId);
+
+        return buildTicketResponse(ticket, attachments, historyLogs);
+    }
+
+    /**
+     * Helper method to fetch and map attachment BLOBs to safe metadata DTOs.
+     */
+    private List<TicketDetailsResponse.AttachmentMetadata> fetchAndMapAttachments(Long ticketId) {
+        return attachmentRepository.findByTicketId(ticketId).stream()
+                .map(attr -> TicketDetailsResponse.AttachmentMetadata.builder()
+                        .id(attr.getId())
+                        .fileType(attr.getFileType() != null ? attr.getFileType().name() : "UNKNOWN")
+                        .fileSizeInBytes(attr.getFile() != null ? attr.getFile().length : 0)
+                        .build())
+                .toList();
+    }
+
+    /**
+     * Helper method to fetch and map chronological audit logs.
+     */
+    private List<TicketDetailsResponse.TicketHistory> fetchAndMapHistory(Long ticketId) {
+        return ticketHistoryRepository.findByTicketId(ticketId).stream()
+                .map(logEntity -> TicketDetailsResponse.TicketHistory.builder()
+                        .id(logEntity.getId())
+                        .description(logEntity.getDescription())
+                        .createdBy(logEntity.getCreatedBy() != null ? logEntity.getCreatedBy().getEmail() : "System")
+                        .createdAt(logEntity.getCreatedAt())
+                        .build())
+                .toList();
+    }
+
+    /**
+     * Helper method to assemble the final response object.
+     */
+    private TicketDetailsResponse buildTicketResponse(
+            TicketEntity ticket,
+            List<TicketDetailsResponse.AttachmentMetadata> attachments,
+            List<TicketDetailsResponse.TicketHistory> historyLogs) {
+
+        return TicketDetailsResponse.builder()
+                .id(ticket.getId())
+                .title(ticket.getTitle())
+                .description(ticket.getDescription())
+                .status(ticket.getStatus())
+                .createdBy(ticket.getCreatedBy() != null ? ticket.getCreatedBy().getEmail() : "Unknown")
+                .createdAt(ticket.getCreatedAt())
+                .updatedAt(ticket.getUpdatedAt())
+                .attachments(attachments)
+                .history(historyLogs)
+                .build();
     }
 }

--- a/tms-backend/src/test/java/cloudsufi/nextgen/tms/service/TicketServiceTest.java
+++ b/tms-backend/src/test/java/cloudsufi/nextgen/tms/service/TicketServiceTest.java
@@ -1,10 +1,13 @@
 package cloudsufi.nextgen.tms.service;
 
+import cloudsufi.nextgen.tms.dto.TicketDetailsResponse;
 import cloudsufi.nextgen.tms.dto.TicketRaiseRequest;
 import cloudsufi.nextgen.tms.dto.TicketRaiseResponse;
 import cloudsufi.nextgen.tms.entity.AttachmentEntity;
 import cloudsufi.nextgen.tms.entity.TicketEntity;
+import cloudsufi.nextgen.tms.entity.TicketHistoryEntity;
 import cloudsufi.nextgen.tms.entity.UserEntity;
+import cloudsufi.nextgen.tms.enums.FileType;
 import cloudsufi.nextgen.tms.enums.Priority;
 import cloudsufi.nextgen.tms.enums.Status;
 import cloudsufi.nextgen.tms.exception.AuthenticationException;
@@ -18,6 +21,7 @@ import cloudsufi.nextgen.tms.repository.UserRepository;
 import cloudsufi.nextgen.tms.util.JwtUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -30,10 +34,13 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -239,5 +246,75 @@ class TicketServiceTest {
 
         assertTrue(exception.getMessage().contains("Failed to read attachment data for file"));
         verifyNoInteractions(attachmentRepository);
+    }
+
+
+    /**
+     * Tests the successful retrieval of a ticket by a valid ID.
+     * Scenario: A valid ticket ID is provided, and the core ticket, along
+     * with its associated attachments and history logs, exists in the database.
+     * Expected Outcome: The service should successfully fetch data from all
+     * three repositories, correctly map the entities (including calculating the BLOB
+     * file sizes) into a {@link TicketDetailsResponse}, and return the comprehensive DTO.
+     */
+    @Test
+    @DisplayName("getTicketById - Should return complete ticket details when ID is valid")
+    void getTicketById_ValidId_ReturnsComprehensiveResponse() {
+        // GIVEN
+        Long ticketId = 100L;
+
+        when(ticketRepository.findById(ticketId)).thenReturn(Optional.of(mockTicket));
+
+        AttachmentEntity mockAttachment = AttachmentEntity.builder()
+                .id(1L)
+                .fileType(FileType.IMAGE)
+                .file(new byte[1024])
+                .build();
+        when(attachmentRepository.findByTicketId(ticketId)).thenReturn(List.of(mockAttachment));
+
+        TicketHistoryEntity mockHistory = TicketHistoryEntity.builder()
+                .id(1L)
+                .description("Ticket Created")
+                .createdBy(mockUser)
+                .createdAt(LocalDateTime.now())
+                .build();
+        when(ticketHistoryRepository.findByTicketId(ticketId)).thenReturn(List.of(mockHistory));
+
+        TicketDetailsResponse response = ticketService.getTicketById(ticketId);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getId()).isEqualTo(ticketId);
+
+        assertThat(response.getAttachments()).hasSize(1);
+        assertThat(response.getAttachments().get(0).getFileSizeInBytes()).isEqualTo(1024);
+
+        assertThat(response.getHistory()).hasSize(1);
+        assertThat(response.getHistory().get(0).getDescription()).isEqualTo("Ticket Created");
+
+        verify(ticketRepository, times(1)).findById(ticketId);
+        verify(attachmentRepository, times(1)).findByTicketId(ticketId);
+        verify(ticketHistoryRepository, times(1)).findByTicketId(ticketId);
+    }
+    /**
+     * Tests the behavior when attempting to retrieve a ticket that does not exist.
+     * Scenario: An invalid or non-existent ticket ID is provided to the service.
+     * Expected Outcome: The service should throw a {@link ResourceNotFoundException}
+     * immediately after failing to find the core ticket.
+     */
+    @Test
+    @DisplayName("getTicketById - Should throw ResourceNotFoundException when ID does not exist")
+    void getTicketById_InvalidId_ThrowsResourceNotFoundException() {
+        // GIVEN
+        Long invalidId = 999L;
+
+        when(ticketRepository.findById(invalidId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> ticketService.getTicketById(invalidId))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("Ticket not found with ID: " + invalidId);
+
+        verify(ticketRepository, times(1)).findById(invalidId);
+        verify(attachmentRepository, never()).findByTicketId(anyLong());
+        verify(ticketHistoryRepository, never()).findByTicketId(anyLong());
     }
 }


### PR DESCRIPTION
- Added GET endpoint returning core ticket data, chronological history, and file attachment metadata.
- Optimized database fetching by using separate repository calls for child entities.
- Implemented robust error handling (404) for invalid ticket IDs.
- Added comprehensive unit tests.