### PR TITLE
fix: remove duplicate return statement in AuthService login method

### DIFF
--- a/tms-backend/src/main/java/cloudsufi/nextgen/tms/service/AuthService.java
+++ b/tms-backend/src/main/java/cloudsufi/nextgen/tms/service/AuthService.java
@@ -101,9 +101,6 @@ public class AuthService {
 
         log.info("Login successful for email: {}", request.getEmail());
 
-        return LoginResponseDTO.builder()
-                .token(token)
-                .tokenType("Bearer")
 
         return LoginResponseDTO.builder()
                 .token(token)


### PR DESCRIPTION
## Issue
During merge conflict resolution of PR #60, a duplicate return statement 
was accidentally left in the AuthService login() method, causing a 
compilation error.

## Changes 
- Removed the duplicate incomplete return statement in AuthService.java
- Kept the correct return statement with all required fields 
  (token, tokenType, role, id, username, email, phoneNo)

## Cause
When resolving merge conflicts manually, the first incomplete 
return block was not fully removed before committing.