### PR TITLE
feat: integrate GET /api/tickets/my API to replace mock data on dashboard

### DIFF
--- a/tms-frontend/src/hooks/useTickets.js
+++ b/tms-frontend/src/hooks/useTickets.js
@@ -15,7 +15,7 @@
   * @author Priyanshu Gupta
   */
 
-import { useState } from 'react';
+import { useState,useEffect  } from 'react';
 import { initialTickets } from '../data/tickets';
 
 /**
@@ -38,9 +38,50 @@ export const useTickets = () => {
    * Master list of all tickets in the system.
    * Initialized with mock data.
    */
-  const [tickets, setTickets] = useState(initialTickets);
-  const [search, setSearch] = useState('');
-  const [statusFilter, setStatusFilter] = useState('');
+
+  const [tickets, setTickets] = useState([]);
+    const [search, setSearch] = useState('');
+    const [statusFilter, setStatusFilter] = useState('');
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+
+    /**
+     * Fetches all tickets for the authenticated user from the backend on component mount.
+     * Replaces the previous mock data initialization with a real API call.
+     * Calls GET /api/tickets/my — returns tickets where user is creator or assignee.
+     * [Ticket Update]: Integrated real backend API to replace initialTickets mock data.
+     * @author Priyanshu Gupta
+     */
+
+
+    useEffect(() => {
+     // Set loading state before API call
+      const fetchTickets = async () => {
+        setLoading(true);
+        try {
+          const token = localStorage.getItem('token');
+          const response = await fetch('http://localhost:8080/api/tickets/my', {
+            method: 'GET',
+            headers: {
+              'Authorization': `Bearer ${token}`
+            }
+          });
+          if (!response.ok) {
+            const errorData = await response.json();
+            throw new Error(errorData.message || 'Failed to fetch tickets');
+          }
+          const data = await response.json();
+          setTickets(data);
+        } catch (err) {
+          console.error('Error fetching tickets:', err);
+          setError(err.message);
+        } finally {
+          setLoading(false);
+        }
+      };
+
+      fetchTickets();
+    }, []);
 
   /**
    * Derives the filtered ticket list from the master tickets array.
@@ -55,26 +96,28 @@ export const useTickets = () => {
      * If search is empty, all tickets pass this check.
      */
     const matchesSearch =
-      !query ||
-      ticket.title.toLowerCase().includes(query) ||
-      ticket.desc.toLowerCase().includes(query) ||
-      ticket.category.toLowerCase().includes(query);
+         !query ||
+         ticket.title?.toLowerCase().includes(query) ||
+         ticket.description?.toLowerCase().includes(query) ||
+         ticket.category?.toLowerCase().includes(query);
 
     /*
      * Check if the ticket matches the selected status filter.
      * If no filter is selected (empty string), all tickets pass.
      */
-    const matchesStatus = !statusFilter || ticket.status === statusFilter;
+
+    const matchesStatus = !statusFilter ||
+      ticket.status?.toLowerCase() === statusFilter.toLowerCase();
 
     return matchesSearch && matchesStatus;
   });
 
 
-  const stats = {
-    open:             tickets.filter((t) => t.status === 'open').length,
-    in_progress:      tickets.filter((t) => t.status === 'in_progress').length,
-    pending_approval: tickets.filter((t) => t.status === 'pending_approval').length,
-    resolved:         tickets.filter((t) => t.status === 'resolved').length,
+const stats = {
+    open:             tickets.filter((t) => t.status?.toUpperCase() === 'OPEN').length,
+    in_progress:      tickets.filter((t) => t.status?.toUpperCase() === 'IN_PROGRESS').length,
+    pending_approval: tickets.filter((t) => t.status?.toUpperCase() === 'PENDING_APPROVAL').length,
+    resolved:         tickets.filter((t) => t.status?.toUpperCase() === 'RESOLVED').length,
   };
 
   const createTicket = async ({ title, desc, priority, category, files }) => {
@@ -111,13 +154,14 @@ export const useTickets = () => {
       }
   };
   return {
-    tickets: filteredTickets,
-    stats,
-    search,
-    setSearch,
-    statusFilter,
-    setStatusFilter,
-    createTicket,
-
-   }
+     tickets: filteredTickets,
+     stats,
+     search,
+     setSearch,
+     statusFilter,
+     setStatusFilter,
+     createTicket,
+     loading,
+     error,
+    }
   };


### PR DESCRIPTION
## Changes 
- Removed mock data (initialTickets) from useTickets.js
- Added useEffect to fetch real tickets from GET /api/tickets/my on dashboard load
- Added loading and error state handling
- Updated search filter to use `description` field (backend field name)
- Updated status filter to handle case-insensitive comparison
- Updated stats counters to handle uppercase status values from backend
